### PR TITLE
Add Darwin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ include python
 include python::virtualenv
 ```
 
-This module supports Debian, RedHat, OpenBSD, Solaris, and Windows platforms
+This module supports Debian, RedHat, OpenBSD, Solaris, Windows, and Darwin platforms
 -- Windows users should read the [Windows Notes](#windows-notes).
 
 Python Classes

--- a/manifests/darwin.pp
+++ b/manifests/darwin.pp
@@ -1,0 +1,62 @@
+# == Class: python::darwin
+#
+# Performs the setup necessary (e.g., downloading the installation MSI) to
+# install Python.  Also sets variables (like $site_packages, $interpreter)
+# that have to be specially calculated on Darwin.
+#
+# === Parameters
+#
+# [*arch*]
+#  The architecture of Python to install, defaults to the architecture of
+#  the system (e.g., 'x64' on 64-bit system).
+#
+# [*allusers*]
+#  Whether to install Python for all users, defaults to true.
+#
+# [*base_url*]
+#  The base url to use when downloading Python, undefined by default.
+#
+# [*source*]
+#  The HTTP or UNC source to the Python package, undefined by default.
+#
+# [*targetdir*]
+#  The target installation directory to use for the Python package,
+#  undefined by default.
+#
+# [*version*]
+#  The version of Python to install, defaults to '2.7.6'.
+#
+# [*darwin_path*]
+#  Whether or not to add Python directory to the Darwin system %Path%,
+#  defaults to true.
+#
+class python::darwin(
+  $allusers  = true,
+  $arch      = $::architecture,
+  $base_url  = undef,
+  $source    = undef,
+  $targetdir = undef,
+  $version   = $python::params::full_version,
+  $darwin_path  = true,
+) inherits python::params {
+
+  $basename = "python-${version}-macosx10.6.pkg"
+
+  $package = "python-${version}-macosx10.6"
+
+  if $base_url {
+      $source_uri = "${base_url}${basename}"
+    } else {
+      $source_uri = "http://www.python.org/ftp/python/${version}/${basename}"
+    }
+
+  $package_source = $source_uri
+
+  if $allusers {
+    $allusers_val = '1'
+  } else {
+    $allusers_val = '0'
+  }
+
+  # Determining Python's path.
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,17 @@ class python (
 
     # Ensure that python::windows comes before the package.
     Class['python::windows'] -> Package[$python_package]
+  } elsif $::osfamily == 'Darwin' {
+    include python::darwin
+    # Get install options, package name and source for Darwin.
+    $install_options = $python::darwin::install_options
+    $package_source = $python::darwin::package_source
+    $python_package = $python::darwin::package
+
+    # Set up variables that couldn't be set in python::params.
+    $interpreter = $python::darwin::interpreter
+    $scripts = $python::darwin::scripts
+    $site_packages = $python::darwin::site_packages
   } else {
     $install_options = undef
     $package_source = $source

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,6 @@
 # == Class: python
 #
 # Platform-dependent parameters for Python.
-#
 class python::params {
   case $::osfamily {
     openbsd: {
@@ -70,6 +69,14 @@ class python::params {
       $full_version  = '2.7.7'
       # Other parameters, like $package, $interpreter, and $site_packages
       # are set by `python::windows`.
+    }
+    Darwin: {
+      $ensure       = 'installed'
+      $version      = '2.7'
+      $full_version = '2.7.9'
+      $pip           = 'python-pip'
+      $interpreter   = '/usr/bin/python'
+      $scripts      = '/usr/local/bin'
     }
     default: {
       fail("Do not know how to install/configure Python on ${::osfamily}.\n")


### PR DESCRIPTION
Adds OS X support to the module. Tested on 10.10 from a fresh installed machine with XCode 5 and command line tools installed.