### PR TITLE
Don't upgrade package dependencies if not necessary

### DIFF
--- a/lib/puppet_x/counsyl/pip.rb
+++ b/lib/puppet_x/counsyl/pip.rb
@@ -44,7 +44,7 @@ module PuppetX
             # is specified to ensure package is actually installed.
             self.class.instances.each do |pip_package|
               if pip_package.name == pypkg
-                args << '--upgrade'
+                args << '--upgrade --upgrade-strategy only-if-needed'
                 break
               end
             end
@@ -57,7 +57,7 @@ module PuppetX
           when String
             args << "#{pypkg}==#{@resource[:ensure]}"
           when :latest
-            args << '--upgrade' << pypkg
+            args << '--upgrade --upgrade-strategy only-if-needed' << pypkg
           else
             args << pypkg
           end


### PR DESCRIPTION
@jdavisp3 @tajmorton 

This `--upgrade` default strategy seems a little non-intuitive. If let's say I had a manifest that installed `pkgA==1.2.1` and `pkgB==1.3.1`. But `pkgA` had an `install_requires` defined for `pkgB>=1`. Then when we run `--upgrade` when installing `pkgA` `pkgB` will be installed to the `latest>=1`, not `1.3.1`. This will cause an environment that continually installs and uninstalls these packages.

To Do:
- [ ] We should probably check that `upgrade-strategy` isn't already specified in `args`. Can someone that knows ruby better than I do help here?